### PR TITLE
refactor: Remove `original_image` field from `SaveGuideRequest` and `…

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -569,7 +569,6 @@ class SaveGuideRequest(BaseModel):
     title: str
     description: Optional[str] = None
     steps: list
-    original_image: Optional[str] = None # Base64 string of the original image
 
 @app.post("/api/seed-guide/save")
 async def save_seed_guide_endpoint(request: SaveGuideRequest):

--- a/frontend/app/seed_guide/page.tsx
+++ b/frontend/app/seed_guide/page.tsx
@@ -22,7 +22,6 @@ interface SavedGuide {
     message?: string;
     created_at: string;
     steps: Step[];
-    original_image?: string;
 }
 
 export default function SeedGuidePage() {


### PR DESCRIPTION
…SeedGuide` interfaces.